### PR TITLE
Cache access tokens

### DIFF
--- a/src/Keycloak.Net.Core/Caching/IKeycloakAccessTokenCache.cs
+++ b/src/Keycloak.Net.Core/Caching/IKeycloakAccessTokenCache.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Keycloak.Net.Core.Caching;
+
+public interface IKeycloakAccessTokenCache
+{
+    Task<string> GetFromCacheAsync(string key, CancellationToken cancellationToken = default);
+    Task AddToCacheAsync(string key, string accessToken, CancellationToken cancellationToken = default);
+    Task<bool> RemoveFromCacheAsync(string key, CancellationToken cancellationToken = default);
+    Task ClearCacheAsync(CancellationToken cancellationToken = default);
+
+    TimeSpan FlushPeriod { get; }
+}

--- a/src/Keycloak.Net.Core/Caching/InMemoryKeycloakAccessTokenCache.cs
+++ b/src/Keycloak.Net.Core/Caching/InMemoryKeycloakAccessTokenCache.cs
@@ -1,0 +1,196 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Keycloak.Net.Core.Caching;
+
+public sealed class InMemoryKeycloakAccessTokenCache : IKeycloakAccessTokenCache
+{
+    private static readonly ReaderWriterLockSlim _locker;
+    private static readonly IDictionary<string, (string, DateTime)> _cache;
+    private static DateTime _lastFlush;
+
+    static InMemoryKeycloakAccessTokenCache()
+    {
+        _locker = new ReaderWriterLockSlim();
+        _cache = new Dictionary<string, (string, DateTime)>(StringComparer.OrdinalIgnoreCase);
+        _lastFlush = DateTime.UtcNow;
+    }
+
+    public Task<string> GetFromCacheAsync(string key, CancellationToken cancellationToken)
+    {
+        _locker.EnterUpgradeableReadLock();
+
+        try
+        {
+            if (!_cache.TryGetValue(key, out var cachedToken))
+            {
+                return Task.FromResult(string.Empty);
+            }
+
+            if (cachedToken.Item2 < DateTime.UtcNow)
+            {
+                _locker.EnterWriteLock();
+
+                try
+                {
+                    _cache.Remove(key);
+
+                    return Task.FromResult(string.Empty);
+                }
+                finally
+                {
+                    _locker.ExitWriteLock();
+                }
+            }
+
+            return Task.FromResult(cachedToken.Item1);
+        }
+        finally
+        {
+            _locker.ExitUpgradeableReadLock();
+        }
+    }
+
+    public async Task AddToCacheAsync(string key, string accessToken, CancellationToken cancellationToken)
+    {
+        JwtSecurityToken token;
+
+        try
+        {
+            token = GetAccessToken(accessToken);
+        }
+        catch
+        {
+            // Do we care anything went wrong?
+
+            return;
+        }
+
+        var expires = token.ValidTo.ToUniversalTime();
+
+        if (expires < DateTime.UtcNow)
+        {
+            return;
+        }
+
+        var shouldFlush = false;
+
+        _locker.EnterWriteLock();
+
+        try
+        {
+            _cache[key] = (accessToken, expires);
+
+            var ts = DateTime.UtcNow - _lastFlush;
+
+            if (ts >= FlushPeriod)
+            {
+                shouldFlush = true;
+            }
+        }
+        finally
+        {
+            _locker.ExitWriteLock();
+        }
+
+        if (shouldFlush)
+        {
+            await FlushCacheAsync(cancellationToken);
+        }
+    }
+
+    public Task<bool> RemoveFromCacheAsync(string key, CancellationToken cancellationToken)
+    {
+        _locker.EnterUpgradeableReadLock();
+
+        try
+        {
+            if (_cache.TryGetValue(key, out _))
+            {
+                _locker.EnterWriteLock();
+
+                try
+                {
+                    _cache.Remove(key);
+
+                    return Task.FromResult(true);
+                }
+                finally
+                {
+                    _locker.ExitWriteLock();
+                }
+            }
+
+            return Task.FromResult(false);
+        }
+        finally
+        {
+            _locker.ExitUpgradeableReadLock();
+        }
+    }
+
+    public Task ClearCacheAsync(CancellationToken cancellationToken)
+    {
+        _locker.EnterWriteLock();
+
+        try
+        {
+            _cache.Clear();
+
+            _lastFlush = DateTime.UtcNow;
+        }
+        finally
+        {
+            _locker.ExitWriteLock();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private async Task FlushCacheAsync(CancellationToken cancellationToken)
+    {
+        _locker.EnterWriteLock();
+
+        try
+        {
+            var expiredKeys = new List<string>(_cache.Count);
+
+            foreach (var kvp in _cache)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (kvp.Value.Item2 < DateTime.UtcNow)
+                {
+                    expiredKeys.Add(kvp.Key);
+                }
+            }
+
+            foreach (var key in expiredKeys)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                _cache.Remove(key);
+            }
+
+            _lastFlush = DateTime.UtcNow;
+        }
+        finally
+        {
+            _locker.ExitWriteLock();
+        }
+    }
+
+    private JwtSecurityToken GetAccessToken(string accessToken)
+    {
+        var handler = new JwtSecurityTokenHandler();
+        var token = handler.ReadJwtToken(accessToken);
+
+        return token;
+    }
+
+    public TimeSpan FlushPeriod { get; } = TimeSpan.FromMinutes(20);
+}

--- a/src/Keycloak.Net.Core/Keycloak.Net.Core.csproj
+++ b/src/Keycloak.Net.Core/Keycloak.Net.Core.csproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <PackageReference Include="Flurl.Http" Version="4.0.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 

--- a/src/Keycloak.Net.Core/KeycloakClient.cs
+++ b/src/Keycloak.Net.Core/KeycloakClient.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Flurl;
 using Flurl.Http.Configuration;
 using Keycloak.Net.Common.Extensions;
+using Keycloak.Net.Core.Caching;
 
 namespace Keycloak.Net;
 
@@ -75,14 +76,21 @@ public class KeycloakOptions
 	/// <summary>
 	/// It is used only when the authorization realm differs from the target one
 	/// </summary>
-	public string AuthenticationRealm { get; }
-        
-	public KeycloakOptions(string prefix = "",
+	public string? AuthenticationRealm { get; }
+
+	/// <summary>
+	/// Specify a provider to cache access tokens for reuse.
+	/// </summary>
+    public IKeycloakAccessTokenCache? AccessTokenCache { get; }
+
+    public KeycloakOptions(string prefix = "",
 						   string adminClientId = "admin-cli",
-						   string? authenticationRealm = default)
+						   string? authenticationRealm = null,
+                           IKeycloakAccessTokenCache? accessTokenCache = null)
 	{
 		Prefix = prefix.TrimStart('/').TrimEnd('/');
 		AdminClientId = adminClientId;
 		AuthenticationRealm = authenticationRealm;
+		AccessTokenCache = accessTokenCache;
 	}
 }


### PR DESCRIPTION
Added ability to cache access tokens using a pluggable provider.

The provider just needs to implement `IKeycloakAccessTokenCache` and supply an instance in `KeycloakOptions` and then flurl extension will use it when trying to get new access tokens.

Expiry in the cache is based on the expiry of the access token itself.

Supplied an in-memory provider but also used it with the likes of Redis for sharing across multiple compute instances.

Note: By default the access tokens in Keycloak (at least in master) are set to 1 minute lifetime so caching them in this instance might be pointless. Things like Auth0 issue access tokens with much longer lifetimes (24 hours). I'd suggest increasing lifetime in Keycloak in combination with this, depending on usage requirements.