### PR TITLE
Add latest organization API endpoints

### DIFF
--- a/src/Keycloak.Net.Core/Models/Groups/Group.cs
+++ b/src/Keycloak.Net.Core/Models/Groups/Group.cs
@@ -6,8 +6,14 @@ public class Group
 	public string Id { get; set; }
 	[JsonPropertyName("name")]
 	public string Name { get; set; }
+	[JsonPropertyName("description")]
+	public string Description { get; set; }
 	[JsonPropertyName("path")]
 	public string Path { get; set; }
+	[JsonPropertyName("parentId")]
+	public string ParentId { get; set; }
+	[JsonPropertyName("subGroupCount")]
+	public long? SubGroupCount { get; set; }
 	[JsonPropertyName("subGroups")]
 	public IEnumerable<Group> Subgroups { get; set; }
 	[JsonPropertyName("realmRoles")]
@@ -16,4 +22,6 @@ public class Group
 	public IDictionary<string, IEnumerable<string>> ClientRoles { get; set; }
 	[JsonPropertyName("attributes")]
 	public IDictionary<string, IEnumerable<string>> Attributes { get; set; }
+	[JsonPropertyName("access")]
+	public IDictionary<string, bool> Access { get; set; }
 }

--- a/src/Keycloak.Net.Core/Models/IdentityProviders/IdentityProvider.cs
+++ b/src/Keycloak.Net.Core/Models/IdentityProviders/IdentityProvider.cs
@@ -4,6 +4,8 @@ public class IdentityProvider
 {
 	[JsonPropertyName("alias")]
 	public string Alias { get; set; }
+	[JsonPropertyName("displayName")]
+	public string? DisplayName { get; set; }
 	[JsonPropertyName("internalId")]
 	public string InternalId { get; set; }
 	[JsonPropertyName("providerId")]
@@ -22,8 +24,18 @@ public class IdentityProvider
 	public bool? AuthenticateByDefault { get; set; }
 	[JsonPropertyName("linkOnly")]
 	public bool? LinkOnly { get; set; }
+	[JsonPropertyName("hideOnLogin")]
+	public bool? HideOnLogin { get; set; }
 	[JsonPropertyName("firstBrokerLoginFlowAlias")]
 	public string FirstBrokerLoginFlowAlias { get; set; }
+	[JsonPropertyName("postBrokerLoginFlowAlias")]
+	public string? PostBrokerLoginFlowAlias { get; set; }
+	[JsonPropertyName("organizationId")]
+	public string? OrganizationId { get; set; }
 	[JsonPropertyName("config")]
 	public Config Config { get; set; }
+	[JsonPropertyName("types")]
+	public IEnumerable<string>? Types { get; set; }
+	[JsonPropertyName("updateProfileFirstLogin")]
+	public bool? UpdateProfileFirstLogin { get; set; }
 }

--- a/src/Keycloak.Net.Core/Models/Organizations/Organization.cs
+++ b/src/Keycloak.Net.Core/Models/Organizations/Organization.cs
@@ -1,4 +1,5 @@
 ﻿using Keycloak.Net.Core.Models.Organizations;
+using Keycloak.Net.Models.Groups;
 using Keycloak.Net.Models.IdentityProviders;
 
 namespace Keycloak.Net.Models.Organizations;
@@ -34,4 +35,7 @@ public class Organization
 
 	[JsonPropertyName("identityProviders")]
 	public IEnumerable<IdentityProvider>? IdentityProviders { get; set; }
+
+	[JsonPropertyName("groups")]
+	public IEnumerable<Group>? Groups { get; set; }
 }

--- a/src/Keycloak.Net.Core/Models/Organizations/OrganizationInvitation.cs
+++ b/src/Keycloak.Net.Core/Models/Organizations/OrganizationInvitation.cs
@@ -1,0 +1,31 @@
+namespace Keycloak.Net.Models.Organizations;
+
+public class OrganizationInvitation
+{
+	[JsonPropertyName("id")]
+	public string? Id { get; set; }
+
+	[JsonPropertyName("organizationId")]
+	public string? OrganizationId { get; set; }
+
+	[JsonPropertyName("email")]
+	public string? Email { get; set; }
+
+	[JsonPropertyName("firstName")]
+	public string? FirstName { get; set; }
+
+	[JsonPropertyName("lastName")]
+	public string? LastName { get; set; }
+
+	[JsonPropertyName("sentDate")]
+	public int? SentDate { get; set; }
+
+	[JsonPropertyName("expiresAt")]
+	public int? ExpiresAt { get; set; }
+
+	[JsonPropertyName("status")]
+	public string? Status { get; set; }
+
+	[JsonPropertyName("inviteLink")]
+	public string? InviteLink { get; set; }
+}

--- a/src/Keycloak.Net.Core/Models/Users/SocialLink.cs
+++ b/src/Keycloak.Net.Core/Models/Users/SocialLink.cs
@@ -1,0 +1,13 @@
+namespace Keycloak.Net.Models.Users;
+
+public class SocialLink
+{
+	[JsonPropertyName("socialProvider")]
+	public string? SocialProvider { get; set; }
+
+	[JsonPropertyName("socialUserId")]
+	public string? SocialUserId { get; set; }
+
+	[JsonPropertyName("socialUsername")]
+	public string? SocialUsername { get; set; }
+}

--- a/src/Keycloak.Net.Core/Models/Users/User.cs
+++ b/src/Keycloak.Net.Core/Models/Users/User.cs
@@ -30,6 +30,8 @@ public class User
 	public UserAccess Access { get; set; }
 	[JsonPropertyName("attributes")]
 	public Dictionary<string, IEnumerable<string>> Attributes { get; set; }
+	[JsonPropertyName("userProfileMetadata")]
+	public UserProfileMetadata? UserProfileMetadata { get; set; }
 	[JsonPropertyName("clientConsents")]
 	public IEnumerable<UserConsent> ClientConsents { get; set; }
 	[JsonPropertyName("clientRoles")]
@@ -42,6 +44,10 @@ public class User
 	public string FederationLink { get; set; }
 	[JsonPropertyName("groups")]
 	public IEnumerable<string> Groups { get; set; }
+	[JsonPropertyName("applicationRoles")]
+	public IDictionary<string, IEnumerable<string>>? ApplicationRoles { get; set; }
+	[JsonPropertyName("socialLinks")]
+	public IEnumerable<SocialLink>? SocialLinks { get; set; }
 	[JsonPropertyName("origin")]
 	public string Origin { get; set; }
 	[JsonPropertyName("realmRoles")]

--- a/src/Keycloak.Net.Core/Models/Users/UserProfileAttributeGroupMetadata.cs
+++ b/src/Keycloak.Net.Core/Models/Users/UserProfileAttributeGroupMetadata.cs
@@ -1,0 +1,16 @@
+namespace Keycloak.Net.Models.Users;
+
+public class UserProfileAttributeGroupMetadata
+{
+	[JsonPropertyName("name")]
+	public string? Name { get; set; }
+
+	[JsonPropertyName("displayHeader")]
+	public string? DisplayHeader { get; set; }
+
+	[JsonPropertyName("displayDescription")]
+	public string? DisplayDescription { get; set; }
+
+	[JsonPropertyName("annotations")]
+	public IDictionary<string, object>? Annotations { get; set; }
+}

--- a/src/Keycloak.Net.Core/Models/Users/UserProfileAttributeMetadata.cs
+++ b/src/Keycloak.Net.Core/Models/Users/UserProfileAttributeMetadata.cs
@@ -1,0 +1,31 @@
+namespace Keycloak.Net.Models.Users;
+
+public class UserProfileAttributeMetadata
+{
+	[JsonPropertyName("name")]
+	public string? Name { get; set; }
+
+	[JsonPropertyName("displayName")]
+	public string? DisplayName { get; set; }
+
+	[JsonPropertyName("required")]
+	public bool? Required { get; set; }
+
+	[JsonPropertyName("readOnly")]
+	public bool? ReadOnly { get; set; }
+
+	[JsonPropertyName("annotations")]
+	public IDictionary<string, object>? Annotations { get; set; }
+
+	[JsonPropertyName("validators")]
+	public IDictionary<string, IDictionary<string, object>>? Validators { get; set; }
+
+	[JsonPropertyName("group")]
+	public string? Group { get; set; }
+
+	[JsonPropertyName("multivalued")]
+	public bool? Multivalued { get; set; }
+
+	[JsonPropertyName("defaultValue")]
+	public string? DefaultValue { get; set; }
+}

--- a/src/Keycloak.Net.Core/Models/Users/UserProfileMetadata.cs
+++ b/src/Keycloak.Net.Core/Models/Users/UserProfileMetadata.cs
@@ -1,0 +1,10 @@
+namespace Keycloak.Net.Models.Users;
+
+public class UserProfileMetadata
+{
+	[JsonPropertyName("attributes")]
+	public IEnumerable<UserProfileAttributeMetadata>? Attributes { get; set; }
+
+	[JsonPropertyName("groups")]
+	public IEnumerable<UserProfileAttributeGroupMetadata>? Groups { get; set; }
+}

--- a/src/Keycloak.Net.Core/Organizations/KeycloakClient.cs
+++ b/src/Keycloak.Net.Core/Organizations/KeycloakClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Net.Http;
 using Keycloak.Net.Models.Groups;
 using Keycloak.Net.Models.IdentityProviders;
 using Keycloak.Net.Models.Organizations;
@@ -149,7 +150,8 @@ public partial class KeycloakClient
 			[nameof(subGroupsCount)] = subGroupsCount
 		};
 
-		return await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/groups/group-by-path/{path}")
+		return await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/groups/group-by-path")
+									  .AppendPathSegment(path, true)
 									  .SetQueryParams(queryParams)
 									  .GetJsonAsync<Group>(cancellationToken: cancellationToken)
 									  .ConfigureAwait(false);
@@ -260,7 +262,7 @@ public partial class KeycloakClient
 															CancellationToken cancellationToken = default)
 	{
 		var response = await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/groups/{groupId}/members/{userId}")
-											  .PutJsonAsync(null, cancellationToken: cancellationToken)
+											  .PutAsync(new StringContent(""), cancellationToken: cancellationToken)
 											  .ConfigureAwait(false);
 		return response.ResponseMessage.IsSuccessStatusCode;
 	}
@@ -396,7 +398,7 @@ public partial class KeycloakClient
 															  CancellationToken cancellationToken = default)
 	{
 		var response = await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/invitations/{invitationId}/resend")
-											  .PostJsonAsync(null, cancellationToken: cancellationToken)
+											  .PostAsync(new StringContent(""), cancellationToken: cancellationToken)
 											  .ConfigureAwait(false);
 		return response.ResponseMessage.IsSuccessStatusCode;
 	}
@@ -414,31 +416,8 @@ public partial class KeycloakClient
 																int? first = null,
 																int? max = null,
 																string? search = null,
+																string? membershipType = null,
 																CancellationToken cancellationToken = default)
-	{
-		var queryParams = new Dictionary<string, object?>
-		{
-			[nameof(exact)] = exact,
-			[nameof(first)] = first,
-			[nameof(max)] = max,
-			[nameof(search)] = search
-		};
-		var response = await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/members")
-											  .SetQueryParams(queryParams)
-											  .GetJsonAsync<List<Member>>(cancellationToken: cancellationToken)
-											  .ConfigureAwait(false);
-		return response;
-
-	}
-
-	public async Task<List<Member>> GetOrganizationMembersByMembershipTypeAsync(string realm,
-																				string organizationId,
-																				string membershipType,
-																				bool? exact = null,
-																				int? first = null,
-																				int? max = null,
-																				string? search = null,
-																				CancellationToken cancellationToken = default)
 	{
 		var queryParams = new Dictionary<string, object?>
 		{
@@ -474,16 +453,6 @@ public partial class KeycloakClient
 											  .ConfigureAwait(false);
 
 		return response.ResponseMessage.IsSuccessStatusCode;
-	}
-
-	public async Task<List<Organization>> GetOrganizationsForMemberAsync(string realm,
-																		 string organizationId,
-																		 string memberId,
-																		 CancellationToken cancellationToken = default)
-	{
-		return await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/members/{memberId}/organizations")
-									  .GetJsonAsync<List<Organization>>(cancellationToken: cancellationToken)
-									  .ConfigureAwait(false);
 	}
 
 	public async Task<List<Organization>> GetOrganizationsForMemberAsync(string realm,

--- a/src/Keycloak.Net.Core/Organizations/KeycloakClient.cs
+++ b/src/Keycloak.Net.Core/Organizations/KeycloakClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Keycloak.Net.Models.Groups;
 using Keycloak.Net.Models.IdentityProviders;
 using Keycloak.Net.Models.Organizations;
 
@@ -77,6 +78,205 @@ public partial class KeycloakClient
 		return location?.Segments.LastOrDefault() ?? throw new InvalidOperationException($"\"{nameof(location)}\" is invalid.");
 	}
 
+	public async Task<long> GetOrganizationsCountAsync(string realm,
+													   bool? exact = null,
+													   string? q = null,
+													   string? search = null,
+													   CancellationToken cancellationToken = default)
+	{
+		var queryParams = new Dictionary<string, object?>
+		{
+			[nameof(exact)] = exact,
+			[nameof(q)] = q,
+			[nameof(search)] = search
+		};
+
+		return await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/count")
+									  .SetQueryParams(queryParams)
+									  .GetJsonAsync<long>(cancellationToken: cancellationToken)
+									  .ConfigureAwait(false);
+	}
+
+	public async Task<List<Group>> GetOrganizationGroupsAsync(string realm,
+															  string organizationId,
+															  bool? briefRepresentation = null,
+															  bool? exact = null,
+															  int? first = null,
+															  int? max = null,
+															  bool? populateHierarchy = null,
+															  string? q = null,
+															  string? search = null,
+															  bool? subGroupsCount = null,
+															  CancellationToken cancellationToken = default)
+	{
+		var queryParams = new Dictionary<string, object?>
+		{
+			[nameof(briefRepresentation)] = briefRepresentation,
+			[nameof(exact)] = exact,
+			[nameof(first)] = first,
+			[nameof(max)] = max,
+			[nameof(populateHierarchy)] = populateHierarchy,
+			[nameof(q)] = q,
+			[nameof(search)] = search,
+			[nameof(subGroupsCount)] = subGroupsCount
+		};
+
+		return await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/groups")
+									  .SetQueryParams(queryParams)
+									  .GetJsonAsync<List<Group>>(cancellationToken: cancellationToken)
+									  .ConfigureAwait(false);
+	}
+
+	public async Task<bool> CreateOrganizationGroupAsync(string realm,
+														 string organizationId,
+														 Group group,
+														 CancellationToken cancellationToken = default)
+	{
+		var response = await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/groups")
+											  .PostJsonAsync(group, cancellationToken: cancellationToken)
+											  .ConfigureAwait(false);
+		return response.ResponseMessage.IsSuccessStatusCode;
+	}
+
+	public async Task<Group> GetOrganizationGroupByPathAsync(string realm,
+															 string organizationId,
+															 string path,
+															 bool? subGroupsCount = null,
+															 CancellationToken cancellationToken = default)
+	{
+		var queryParams = new Dictionary<string, object?>
+		{
+			[nameof(subGroupsCount)] = subGroupsCount
+		};
+
+		return await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/groups/group-by-path/{path}")
+									  .SetQueryParams(queryParams)
+									  .GetJsonAsync<Group>(cancellationToken: cancellationToken)
+									  .ConfigureAwait(false);
+	}
+
+	public async Task<Group> GetOrganizationGroupAsync(string realm,
+													   string organizationId,
+													   string groupId,
+													   bool? subGroupsCount = null,
+													   CancellationToken cancellationToken = default)
+	{
+		var queryParams = new Dictionary<string, object?>
+		{
+			[nameof(subGroupsCount)] = subGroupsCount
+		};
+
+		return await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/groups/{groupId}")
+									  .SetQueryParams(queryParams)
+									  .GetJsonAsync<Group>(cancellationToken: cancellationToken)
+									  .ConfigureAwait(false);
+	}
+
+	public async Task<bool> UpdateOrganizationGroupAsync(string realm,
+														 string organizationId,
+														 string groupId,
+														 Group group,
+														 CancellationToken cancellationToken = default)
+	{
+		var response = await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/groups/{groupId}")
+											  .PutJsonAsync(group, cancellationToken: cancellationToken)
+											  .ConfigureAwait(false);
+		return response.ResponseMessage.IsSuccessStatusCode;
+	}
+
+	public async Task<bool> DeleteOrganizationGroupAsync(string realm,
+														 string organizationId,
+														 string groupId,
+														 CancellationToken cancellationToken = default)
+	{
+		var response = await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/groups/{groupId}")
+											  .DeleteAsync(cancellationToken: cancellationToken)
+											  .ConfigureAwait(false);
+		return response.ResponseMessage.IsSuccessStatusCode;
+	}
+
+	public async Task<List<Group>> GetOrganizationGroupChildrenAsync(string realm,
+																	 string organizationId,
+																	 string groupId,
+																	 bool? exact = null,
+																	 int? first = null,
+																	 int? max = null,
+																	 string? search = null,
+																	 bool? subGroupsCount = null,
+																	 CancellationToken cancellationToken = default)
+	{
+		var queryParams = new Dictionary<string, object?>
+		{
+			[nameof(exact)] = exact,
+			[nameof(first)] = first,
+			[nameof(max)] = max,
+			[nameof(search)] = search,
+			[nameof(subGroupsCount)] = subGroupsCount
+		};
+
+		return await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/groups/{groupId}/children")
+									  .SetQueryParams(queryParams)
+									  .GetJsonAsync<List<Group>>(cancellationToken: cancellationToken)
+									  .ConfigureAwait(false);
+	}
+
+	public async Task<bool> SetOrCreateOrganizationGroupChildAsync(string realm,
+																   string organizationId,
+																   string groupId,
+																   Group group,
+																   CancellationToken cancellationToken = default)
+	{
+		var response = await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/groups/{groupId}/children")
+											  .PostJsonAsync(group, cancellationToken: cancellationToken)
+											  .ConfigureAwait(false);
+		return response.ResponseMessage.IsSuccessStatusCode;
+	}
+
+	public async Task<List<Member>> GetOrganizationGroupMembersAsync(string realm,
+																	 string organizationId,
+																	 string groupId,
+																	 bool? briefRepresentation = null,
+																	 int? first = null,
+																	 int? max = null,
+																	 CancellationToken cancellationToken = default)
+	{
+		var queryParams = new Dictionary<string, object?>
+		{
+			[nameof(briefRepresentation)] = briefRepresentation,
+			[nameof(first)] = first,
+			[nameof(max)] = max
+		};
+
+		return await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/groups/{groupId}/members")
+									  .SetQueryParams(queryParams)
+									  .GetJsonAsync<List<Member>>(cancellationToken: cancellationToken)
+									  .ConfigureAwait(false);
+	}
+
+	public async Task<bool> AddOrganizationGroupMemberAsync(string realm,
+															string organizationId,
+															string groupId,
+															string userId,
+															CancellationToken cancellationToken = default)
+	{
+		var response = await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/groups/{groupId}/members/{userId}")
+											  .PutJsonAsync(null, cancellationToken: cancellationToken)
+											  .ConfigureAwait(false);
+		return response.ResponseMessage.IsSuccessStatusCode;
+	}
+
+	public async Task<bool> DeleteOrganizationGroupMemberAsync(string realm,
+															   string organizationId,
+															   string groupId,
+															   string userId,
+															   CancellationToken cancellationToken = default)
+	{
+		var response = await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/groups/{groupId}/members/{userId}")
+											  .DeleteAsync(cancellationToken: cancellationToken)
+											  .ConfigureAwait(false);
+		return response.ResponseMessage.IsSuccessStatusCode;
+	}
+
 	public async Task<bool> DeleteOrganizationIdentityProviderAsync(string realm,
 																	string organizationId,
 																	string identityProviderAlias,
@@ -114,6 +314,93 @@ public partial class KeycloakClient
 		return response.ResponseMessage.IsSuccessStatusCode;
 	}
 
+	public async Task<List<Group>> GetOrganizationIdentityProviderGroupsAsync(string realm,
+																			  string organizationId,
+																			  string identityProviderAlias,
+																			  bool? briefRepresentation = null,
+																			  bool? exact = null,
+																			  int? first = null,
+																			  int? max = null,
+																			  string? q = null,
+																			  string? search = null,
+																			  bool? subGroupsCount = null,
+																			  CancellationToken cancellationToken = default)
+	{
+		var queryParams = new Dictionary<string, object?>
+		{
+			[nameof(briefRepresentation)] = briefRepresentation,
+			[nameof(exact)] = exact,
+			[nameof(first)] = first,
+			[nameof(max)] = max,
+			[nameof(q)] = q,
+			[nameof(search)] = search,
+			[nameof(subGroupsCount)] = subGroupsCount
+		};
+
+		return await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/identity-providers/{identityProviderAlias}/groups")
+									  .SetQueryParams(queryParams)
+									  .GetJsonAsync<List<Group>>(cancellationToken: cancellationToken)
+									  .ConfigureAwait(false);
+	}
+
+	public async Task<List<OrganizationInvitation>> GetOrganizationInvitationsAsync(string realm,
+																					string organizationId,
+																					string? email = null,
+																					int? first = null,
+																					string? firstName = null,
+																					string? lastName = null,
+																					int? max = null,
+																					string? search = null,
+																					string? status = null,
+																					CancellationToken cancellationToken = default)
+	{
+		var queryParams = new Dictionary<string, object?>
+		{
+			[nameof(email)] = email,
+			[nameof(first)] = first,
+			[nameof(firstName)] = firstName,
+			[nameof(lastName)] = lastName,
+			[nameof(max)] = max,
+			[nameof(search)] = search,
+			[nameof(status)] = status
+		};
+
+		return await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/invitations")
+									  .SetQueryParams(queryParams)
+									  .GetJsonAsync<List<OrganizationInvitation>>(cancellationToken: cancellationToken)
+									  .ConfigureAwait(false);
+	}
+
+	public async Task<OrganizationInvitation> GetOrganizationInvitationAsync(string realm,
+																			 string organizationId,
+																			 string invitationId,
+																			 CancellationToken cancellationToken = default) =>
+		await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/invitations/{invitationId}")
+							   .GetJsonAsync<OrganizationInvitation>(cancellationToken: cancellationToken)
+							   .ConfigureAwait(false);
+
+	public async Task<bool> DeleteOrganizationInvitationAsync(string realm,
+															  string organizationId,
+															  string invitationId,
+															  CancellationToken cancellationToken = default)
+	{
+		var response = await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/invitations/{invitationId}")
+											  .DeleteAsync(cancellationToken: cancellationToken)
+											  .ConfigureAwait(false);
+		return response.ResponseMessage.IsSuccessStatusCode;
+	}
+
+	public async Task<bool> ResendOrganizationInvitationAsync(string realm,
+															  string organizationId,
+															  string invitationId,
+															  CancellationToken cancellationToken = default)
+	{
+		var response = await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/invitations/{invitationId}/resend")
+											  .PostJsonAsync(null, cancellationToken: cancellationToken)
+											  .ConfigureAwait(false);
+		return response.ResponseMessage.IsSuccessStatusCode;
+	}
+
 	public async Task<long> GetOrganizationMembersCountAsync(string realm,
 															 string organizationId,
 															 CancellationToken cancellationToken = default) =>
@@ -134,6 +421,31 @@ public partial class KeycloakClient
 			[nameof(exact)] = exact,
 			[nameof(first)] = first,
 			[nameof(max)] = max,
+			[nameof(search)] = search
+		};
+		var response = await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/members")
+											  .SetQueryParams(queryParams)
+											  .GetJsonAsync<List<Member>>(cancellationToken: cancellationToken)
+											  .ConfigureAwait(false);
+		return response;
+
+	}
+
+	public async Task<List<Member>> GetOrganizationMembersByMembershipTypeAsync(string realm,
+																				string organizationId,
+																				string membershipType,
+																				bool? exact = null,
+																				int? first = null,
+																				int? max = null,
+																				string? search = null,
+																				CancellationToken cancellationToken = default)
+	{
+		var queryParams = new Dictionary<string, object?>
+		{
+			[nameof(exact)] = exact,
+			[nameof(first)] = first,
+			[nameof(max)] = max,
+			[nameof(membershipType)] = membershipType,
 			[nameof(search)] = search
 		};
 		var response = await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/members")
@@ -171,6 +483,46 @@ public partial class KeycloakClient
 	{
 		return await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/members/{memberId}/organizations")
 									  .GetJsonAsync<List<Organization>>(cancellationToken: cancellationToken)
+									  .ConfigureAwait(false);
+	}
+
+	public async Task<List<Organization>> GetOrganizationsForMemberAsync(string realm,
+																		 string organizationId,
+																		 string memberId,
+																		 bool? briefRepresentation = null,
+																		 CancellationToken cancellationToken = default)
+	{
+		var queryParams = new Dictionary<string, object?>
+		{
+			[nameof(briefRepresentation)] = briefRepresentation,
+		};
+
+		return await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/members/{memberId}/organizations")
+									  .SetQueryParams(queryParams)
+									  .GetJsonAsync<List<Organization>>(cancellationToken: cancellationToken)
+									  .ConfigureAwait(false);
+	}
+
+	public async Task<List<Group>> GetOrganizationMemberGroupsAsync(string realm,
+																	string organizationId,
+																	string memberId,
+																	bool? briefRepresentation = null,
+																	int? first = null,
+																	int? max = null,
+																	string? search = null,
+																	CancellationToken cancellationToken = default)
+	{
+		var queryParams = new Dictionary<string, object?>
+		{
+			[nameof(briefRepresentation)] = briefRepresentation,
+			[nameof(first)] = first,
+			[nameof(max)] = max,
+			[nameof(search)] = search
+		};
+
+		return await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/organizations/{organizationId}/members/{memberId}/groups")
+									  .SetQueryParams(queryParams)
+									  .GetJsonAsync<List<Group>>(cancellationToken: cancellationToken)
 									  .ConfigureAwait(false);
 	}
 


### PR DESCRIPTION
## Summary
- add the missing latest Keycloak Organizations endpoints, including organization groups, invitations, identity-provider groups, member groups, and organization count
- extend organization-related models to match the current OpenAPI response shapes
- keep the changes additive and preserve existing method signatures

Closes #76

## Validation
- OpenAPI Organizations route comparison: 36/36 operations covered, no missing or extra verb/path matches
- Organization-related model property comparison against the latest OpenAPI schema
- `dotnet build Keycloak.Net.Core.sln`