### PR TITLE
Add request timeout option

### DIFF
--- a/src/Keycloak.Net.Core/Common/Extensions/FlurlRequestExtensions.cs
+++ b/src/Keycloak.Net.Core/Common/Extensions/FlurlRequestExtensions.cs
@@ -36,17 +36,23 @@ public static class FlurlRequestExtensions
             }
         }
 
-		var result = await url.AppendPathSegment($"{options.Prefix}/realms/{realm}/protocol/openid-connect/token")
-							  .WithHeader("Accept", "application/json")
-							  .PostUrlEncodedAsync(new List<KeyValuePair<string, string>>
-												   {
-													   new("grant_type", "password"),
-													   new("username", userName),
-													   new("password", password),
-													   new("client_id", options.AdminClientId)
-												   })
-							  .ReceiveJson<AccessTokenDto>()
-							  .ConfigureAwait(false);
+		var request = url.AppendPathSegment($"{options.Prefix}/realms/{realm}/protocol/openid-connect/token")
+						 .WithHeader("Accept", "application/json");
+
+		if (options.Timeout.HasValue)
+		{
+			request = request.WithTimeout(options.Timeout.Value);
+		}
+
+		var result = await request.PostUrlEncodedAsync(new List<KeyValuePair<string, string>>
+													   {
+														   new("grant_type", "password"),
+														   new("username", userName),
+														   new("password", password),
+														   new("client_id", options.AdminClientId)
+													   })
+								  .ReceiveJson<AccessTokenDto>()
+								  .ConfigureAwait(false);
 
         if (canCache)
         {
@@ -88,16 +94,22 @@ public static class FlurlRequestExtensions
             }
         }
 
-        var result = await url.AppendPathSegment($"{options.Prefix}/realms/{realm}/protocol/openid-connect/token")
-							  .WithHeader("Content-Type", "application/x-www-form-urlencoded")
-							  .PostUrlEncodedAsync(new List<KeyValuePair<string, string>>
-												   {
-													   new("grant_type", "client_credentials"),
-													   new("client_secret", clientSecret),
-													   new("client_id", options.AdminClientId)
-												   })
-							  .ReceiveJson<AccessTokenDto>()
-							  .ConfigureAwait(false);
+        var request = url.AppendPathSegment($"{options.Prefix}/realms/{realm}/protocol/openid-connect/token")
+						 .WithHeader("Content-Type", "application/x-www-form-urlencoded");
+
+		if (options.Timeout.HasValue)
+		{
+			request = request.WithTimeout(options.Timeout.Value);
+		}
+
+        var result = await request.PostUrlEncodedAsync(new List<KeyValuePair<string, string>>
+													   {
+														   new("grant_type", "client_credentials"),
+														   new("client_secret", clientSecret),
+														   new("client_id", options.AdminClientId)
+													   })
+								  .ReceiveJson<AccessTokenDto>()
+								  .ConfigureAwait(false);
 
         if (canCache)
         {

--- a/src/Keycloak.Net.Core/KeycloakClient.cs
+++ b/src/Keycloak.Net.Core/KeycloakClient.cs
@@ -66,9 +66,12 @@ public partial class KeycloakClient
 													   _clientSecret,
 													   _options);
 
-		return _options.TimeOut.HasValue
-				   ? request.WithTimeout(_options.TimeOut.Value)
-				   : request;
+		if (_options.Timeout.HasValue)
+		{
+			request = request.WithTimeout(_options.Timeout.Value);
+		}
+
+		return request;
 	}
 
 	internal record CountDto(int Count);
@@ -90,20 +93,20 @@ public class KeycloakOptions
     public IKeycloakAccessTokenCache? AccessTokenCache { get; }
 
 	/// <summary>
-	/// Specify a timeout for Keycloak requests.
+	/// Specify the maximum time to wait for HTTP requests.
 	/// </summary>
-	public TimeSpan? TimeOut { get; }
+	public TimeSpan? Timeout { get; }
 
     public KeycloakOptions(string prefix = "",
 						   string adminClientId = "admin-cli",
 						   string? authenticationRealm = null,
                            IKeycloakAccessTokenCache? accessTokenCache = null,
-						   TimeSpan? timeOut = null)
+						   TimeSpan? timeout = null)
 	{
 		Prefix = prefix.TrimStart('/').TrimEnd('/');
 		AdminClientId = adminClientId;
 		AuthenticationRealm = authenticationRealm;
 		AccessTokenCache = accessTokenCache;
-		TimeOut = timeOut;
+		Timeout = timeout;
 	}
 }

--- a/src/Keycloak.Net.Core/KeycloakClient.cs
+++ b/src/Keycloak.Net.Core/KeycloakClient.cs
@@ -54,16 +54,22 @@ public partial class KeycloakClient
 	public void SetSerializer(ISerializer serializer) =>
 		_serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
 
-	private IFlurlRequest GetBaseUrl(string authenticationRealm) =>
-		new Url(_url).AppendPathSegment(_options.Prefix)
-					 .WithSettings(settings => settings.JsonSerializer = _serializer)
-					 .WithAuthentication(_getToken,
-										 _url,
-										 _options.AuthenticationRealm ?? authenticationRealm,
-										 _userName,
-										 _password,
-										 _clientSecret,
-										 _options);
+	private IFlurlRequest GetBaseUrl(string authenticationRealm)
+	{
+		var request = new Url(_url).AppendPathSegment(_options.Prefix)
+								   .WithSettings(settings => settings.JsonSerializer = _serializer)
+								   .WithAuthentication(_getToken,
+													   _url,
+													   _options.AuthenticationRealm ?? authenticationRealm,
+													   _userName,
+													   _password,
+													   _clientSecret,
+													   _options);
+
+		return _options.TimeOut.HasValue
+				   ? request.WithTimeout(_options.TimeOut.Value)
+				   : request;
+	}
 
 	internal record CountDto(int Count);
 }
@@ -83,14 +89,21 @@ public class KeycloakOptions
 	/// </summary>
     public IKeycloakAccessTokenCache? AccessTokenCache { get; }
 
+	/// <summary>
+	/// Specify a timeout for Keycloak requests.
+	/// </summary>
+	public TimeSpan? TimeOut { get; }
+
     public KeycloakOptions(string prefix = "",
 						   string adminClientId = "admin-cli",
 						   string? authenticationRealm = null,
-                           IKeycloakAccessTokenCache? accessTokenCache = null)
+                           IKeycloakAccessTokenCache? accessTokenCache = null,
+						   TimeSpan? timeOut = null)
 	{
 		Prefix = prefix.TrimStart('/').TrimEnd('/');
 		AdminClientId = adminClientId;
 		AuthenticationRealm = authenticationRealm;
 		AccessTokenCache = accessTokenCache;
+		TimeOut = timeOut;
 	}
 }


### PR DESCRIPTION
## Summary
- add an optional `TimeOut` setting to `KeycloakOptions`
- apply the configured timeout to Keycloak requests via Flurl `WithTimeout`
- preserve current behavior when no timeout is configured

Closes #77

## Validation
- `dotnet build Keycloak.Net.Core.sln`